### PR TITLE
ServiceLocatorAwareInterface is deprecated

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -82,8 +82,8 @@ return array(
     ),
 
     'controllers' => array(
-        'invokables' => array(
-            'ElFinderIndexController' => 'Reliv\ElFinder\Controller\IndexController',
+        'factories' => array(
+            'ElFinderIndexController' => 'Reliv\ElFinder\Controller\IndexControllerFactory',
         ),
     ),
 

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -101,7 +101,7 @@ class IndexController extends AbstractActionController
         $viewParams['connectorPath'] = $connectorPath;
 
         $fileType = $this->getEvent()->getRouteMatch()->getParam('fileType');
-        if (!empty($type)) {
+        if (!empty($fileType)) {
             $viewParams['connectorPath'] .= '/' . $fileType;
         }
 

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -39,7 +39,7 @@ use Zend\View\Model\ViewModel;
  */
 class IndexController extends AbstractActionController
 {
-	/**
+    /**
      * @var array
      */
     protected $config;
@@ -101,7 +101,7 @@ class IndexController extends AbstractActionController
         $viewParams['connectorPath'] = $connectorPath;
 
         $fileType = $this->getEvent()->getRouteMatch()->getParam('fileType');
-        if (!empty($fileType)) {
+        if (!empty($type)) {
             $viewParams['connectorPath'] .= '/' . $fileType;
         }
 
@@ -137,7 +137,6 @@ class IndexController extends AbstractActionController
             // set read+write to false, other (locked+hidden) set to true
             : null; // else elFinder decide it itself
     }
-
 
     public function getConfig()
     {

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -39,6 +39,16 @@ use Zend\View\Model\ViewModel;
  */
 class IndexController extends AbstractActionController
 {
+	/**
+     * @var array
+     */
+    protected $config;
+
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
     /**
      * Index Action - Used when index or root document is called.
      *
@@ -131,8 +141,7 @@ class IndexController extends AbstractActionController
 
     public function getConfig()
     {
-        $config = $this->getServiceLocator()->get('config');
-        return $config['elfinder'];
+        return $this->config['elfinder'];
     }
 
     public function getConnectorPath()

--- a/src/Controller/IndexControllerFactory.php
+++ b/src/Controller/IndexControllerFactory.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Index Controller for the entire application
+ *
+ * This file contains the main controller used for the application.  This
+ * should extend from the base class and should need no further modification.
+ *
+ * PHP version 5.3
+ *
+ * LICENSE: No License yet
+ *
+ * @category  Reliv
+ * @author    Unkown <unknown@relivinc.com>
+ * @copyright 2012 Reliv International
+ * @license   License.txt New BSD License
+ * @version   GIT: <git_id>
+ */
+namespace Reliv\ElFinder\Controller;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+/**
+ * Index Controller Factory
+ *
+ *
+ * @author    Cyril Rouillon <cyril@misterpatate.fr>
+ * @copyright 2016
+ * @license   License.txt New BSD License
+ * @version   Release: 1.0
+ *
+ */
+class IndexControllerFactory implements FactoryInterface
+{
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     *
+     * @return mixed
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $sm = $serviceLocator->getServiceLocator();
+        $config = $sm->get('config');
+
+        return new IndexController($config);
+    }
+}

--- a/src/Controller/IndexControllerFactory.php
+++ b/src/Controller/IndexControllerFactory.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * Index Controller for the entire application
+ * Index Controller Factory
  *
- * This file contains the main controller used for the application.  This
- * should extend from the base class and should need no further modification.
+ * This file contains the factory for the main controller used for the application.
  *
  * PHP version 5.3
  *
@@ -19,12 +18,13 @@ namespace Reliv\ElFinder\Controller;
 
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+
 /**
  * Index Controller Factory
  *
- *
- * @author    Cyril Rouillon <cyril@misterpatate.fr>
- * @copyright 2016
+ * @category  Reliv
+ * @author    Westin Shafer <wshafer@relivinc.com>
+ * @copyright 2012 Reliv International
  * @license   License.txt New BSD License
  * @version   Release: 1.0
  *


### PR DESCRIPTION
since ZF 2.7 update the ServiceLocatorAwareInterface is deprecated
inside the Controller.
I propose this patch to resolve the problem.

I create an Issue for the getElFinderConfig() function which is more
complicated.