### PR TITLE
Add use statement to fix type hint

### DIFF
--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -20,6 +20,7 @@ namespace Reliv\ElFinder\Controller;
 use Reliv\ElFinder\Config\ConfigInterface;
 use Reliv\ElFinder\Exception\RuntimeException;
 use Reliv\ElFinder\Exception\InvalidArgumentException;
+use Reliv\ElFinder\Service\ElFinderManager;
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\View\Model\ViewModel;
 


### PR DESCRIPTION
Fix 500 error: "Uncaught TypeError: Argument 2 passed to Reliv\ElFinder\Controller\IndexController::__construct() must be an instance of Reliv\ElFinder\Controller\ElFinderManager, instance of Reliv\ElFinder\Service\ElFinderManager given"