### PR TITLE
Migration to Laminas

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This package uses composer to install.
 
   1. Install the composer package: `composer require reliv/elfinder`
 
-  2. Add 'Reliv\ElFinder' to your list of modules in `[zf2 project folder]/config/application.config.php`
+  2. Add 'Reliv\ElFinder' (and AssetManager) to your list of modules in `[zf2 project folder]/config/application.config.php`
 
   3. (Optional) Configure the module for use in your project (see configuration
      below)

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "zendframework/zendframework": "^3.0",
+        "laminas/laminas-mvc": "^3.1.1",
         "studio-42/elfinder": "2.1.*",
         "rwoverdijk/assetmanager": "1.*",
         "laminas/laminas-dependency-plugin": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": ">=7.0",
         "laminas/laminas-mvc": "^3.1.1",
         "studio-42/elfinder": "2.1.*",
-        "rwoverdijk/assetmanager": "1.*",
+        "rwoverdijk/assetmanager": "2.*",
         "laminas/laminas-dependency-plugin": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,12 @@
         "php": ">=7.0",
         "zendframework/zendframework": "^3.0",
         "studio-42/elfinder": "2.1.*",
-        "rwoverdijk/assetmanager": "1.*"
+        "rwoverdijk/assetmanager": "1.*",
+        "laminas/laminas-dependency-plugin": "^1.0"
     },
     "require-dev": {
-      "phpunit/phpunit": "4.6.*",
-      "squizlabs/php_codesniffer": "2.*"
+        "phpunit/phpunit": "4.6.*",
+        "squizlabs/php_codesniffer": "2.*"
     },
     "autoload": {
         "psr-4": {

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -94,7 +94,7 @@ return array(
     'router' => array(
         'routes' => array(
             'elFinder' => array(
-                'type' => \Zend\Router\Http\Segment::class,
+                'type' => \Laminas\Router\Http\Segment::class,
                 'options' => array(
                     'route' => '/elfinder[/:fileType]',
                     'defaults' => array(
@@ -105,7 +105,7 @@ return array(
                 ),
             ),
             'elFinderConnector' => array(
-                'type' => \Zend\Router\Http\Segment::class,
+                'type' => \Laminas\Router\Http\Segment::class,
                 'options' => array(
                     'route' => '/elfinder/connector[/:fileType]',
                     'defaults' => array(
@@ -116,7 +116,7 @@ return array(
                 ),
             ),
             'elFinderStandAlone' => array(
-                'type' => \Zend\Router\Http\Segment::class,
+                'type' => \Laminas\Router\Http\Segment::class,
                 'options' => array(
                     'route' => '/elfinder/standalone[/:fileType]',
                     'defaults' => array(
@@ -127,7 +127,7 @@ return array(
                 ),
             ),
             'elFinderCkEditor' => array(
-                'type' => \Zend\Router\Http\Segment::class,
+                'type' => \Laminas\Router\Http\Segment::class,
                 'options' => array(
                     'route' => '/elfinder/ckeditor[/:fileType]',
                     'defaults' => array(
@@ -138,7 +138,7 @@ return array(
                 ),
             ),
             'elFinderTinyMce' => array(
-                'type' => \Zend\Router\Http\Segment::class,
+                'type' => \Laminas\Router\Http\Segment::class,
                 'options' => array(
                     'route' => '/elfinder/tinymce[/:fileType]',
                     'defaults' => array(

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -21,8 +21,8 @@ use Reliv\ElFinder\Config\ConfigInterface;
 use Reliv\ElFinder\Exception\RuntimeException;
 use Reliv\ElFinder\Exception\InvalidArgumentException;
 use Reliv\ElFinder\Service\ElFinderManager;
-use Zend\Mvc\Controller\AbstractActionController;
-use Zend\View\Model\ViewModel;
+use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\View\Model\ViewModel;
 
 /**
  * Index Controller for the entire application
@@ -59,7 +59,7 @@ class IndexController extends AbstractActionController
     /**
      * Index Action - Used when index or root document is called.
      *
-     * @return \Zend\View\Model\ViewModel
+     * @return \Laminas\View\Model\ViewModel
      */
     public function indexAction()
     {

--- a/src/Controller/IndexControllerFactory.php
+++ b/src/Controller/IndexControllerFactory.php
@@ -18,10 +18,10 @@ namespace Reliv\ElFinder\Controller;
 
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Index Controller Factory

--- a/src/Service/ElFinderManagerFactory.php
+++ b/src/Service/ElFinderManagerFactory.php
@@ -18,10 +18,10 @@ namespace Reliv\ElFinder\Service;
 
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\Factory\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 class ElFinderManagerFactory implements FactoryInterface
 {


### PR DESCRIPTION
As announced, ZendFramework has moved to Laminas. Please consider this change, which should allow the plugin to run after migration to Laminas.